### PR TITLE
Fix plugin version checks to properly support 1.6.1 release

### DIFF
--- a/plugins/CopyTitle/copytitle.cpp
+++ b/plugins/CopyTitle/copytitle.cpp
@@ -61,7 +61,7 @@ void CopyTitle::unload()
 
 bool CopyTitle::testPlugin()
 {
-    return (QupZilla::VERSION == QLatin1String("1.6.0"));
+    return (QupZilla::VERSION == QLatin1String("1.6.1"));
 }
 
 QTranslator* CopyTitle::getTranslator(const QString &locale)

--- a/plugins/MailHandle/mailhandle_plugin.cpp
+++ b/plugins/MailHandle/mailhandle_plugin.cpp
@@ -66,7 +66,7 @@ bool MailHandle_Plugin::testPlugin()
 {
     // Let's be sure, require latest version of QupZilla
 
-    return (QupZilla::VERSION == QLatin1String("1.6.0"));
+    return (QupZilla::VERSION == QLatin1String("1.6.1"));
 }
 
 QTranslator* MailHandle_Plugin::getTranslator(const QString &locale)

--- a/plugins/Videoner/videoner_plugin.cpp
+++ b/plugins/Videoner/videoner_plugin.cpp
@@ -62,7 +62,7 @@ bool Videoner_Plugin::testPlugin()
 {
     // Let's be sure, require latest version of QupZilla
 
-    return (QupZilla::VERSION == QLatin1String("1.6.0"));
+    return (QupZilla::VERSION == QLatin1String("1.6.1"));
 }
 
 QTranslator* Videoner_Plugin::getTranslator(const QString &locale)


### PR DESCRIPTION
As per summary. Three plugins are broken with 1.6.1 because of version check was not updated. This patch will hopefully fix it(until next release ;-)). After applying this trivial fix - plugins loaded and worked fine.
